### PR TITLE
Update rails_admin dependency

### DIFF
--- a/lib/rails_admin_shrine/version.rb
+++ b/lib/rails_admin_shrine/version.rb
@@ -1,3 +1,3 @@
 module RailsAdminShrine
-  VERSION = "0.0.2"
+  VERSION = "0.0.3"
 end

--- a/rails_admin_shrine.gemspec
+++ b/rails_admin_shrine.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
 
-  s.add_dependency 'rails_admin', '>= 0.7.0'
+  s.add_dependency 'rails_admin', '>= 1.1.1'
 end


### PR DESCRIPTION
This updates the rails_admin version rails_admin_shrine depends on. This fixes some recent compatibility issues.