### PR TITLE
Newer improved version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-= RailsAdminShrine
+# RailsAdminShrine
 
 This project rocks and uses MIT-LICENSE.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ You can specify the field as a **'shrine'** type if not detected:
 
 ## Deleting attachment
 
-You need to define a **delete method** if you want to delete attachment:
+You need to define a **delete method** if you want to delete attachment.
+
+(Or you can simply use the [remove_attachment](https://github.com/shrinerb/shrine/blob/master/lib/shrine/plugins/remove_attachment.rb) plugin for this)
 
 ```ruby
 class Article < ActiveRecord::Base

--- a/README.md
+++ b/README.md
@@ -1,3 +1,44 @@
 # RailsAdminShrine
 
-This project rocks and uses MIT-LICENSE.
+Install and configure [shrine](https://github.com/shrinerb/shrine).
+
+Suppose your model looks like this:
+
+```ruby
+class Article < ActiveRecord::Base
+  include ImageUploader.attachment(:asset)
+end
+```
+
+You can specify the field as a **'shrine'** type if not detected:
+
+```ruby
+  field :asset, :shrine
+```
+
+## Deleting attachment
+
+You need to define a **delete method** if you want to delete attachment:
+
+```ruby
+class Article < ActiveRecord::Base
+  include ImageUploader.attachment(:asset)
+  
+  attr_accessor :remove_asset
+  after_save do
+    next unless remove_asset == '1'
+    self.remove_asset = nil
+    update(image: nil)
+  end
+end
+```
+
+The method name is `remove_#{name}` by default, but you can configure it using `delete_method` option:
+
+```ruby
+field :asset, :shrine do
+  delete_method :delete_asset
+end
+```
+
+### This project rocks and uses MIT-LICENSE.

--- a/lib/rails_admin_shrine.rb
+++ b/lib/rails_admin_shrine.rb
@@ -13,9 +13,15 @@ module RailsAdmin
           register_instance_option :thumb_method do
             unless defined? @thumb_method
               @thumb_method = begin
-                attacher = bindings[:object].public_send("#{name}_attacher".to_sym)
-                versions = attacher.shrine_class.version_names.map { |v| v.to_sym }
-                versions.detect { |v| v.in?(%i[thumb thumbnail]) } || versions.first
+                next nil unless value.is_a?(Hash)
+
+                if value.key?(:thumb)
+                  :thumb
+                elsif value.key?(:thumbnail)
+                  :thumbnail
+                else
+                  value.keys.first
+                end
               end
             end
             @thumb_method

--- a/lib/rails_admin_shrine.rb
+++ b/lib/rails_admin_shrine.rb
@@ -22,7 +22,7 @@ module RailsAdmin
           end
 
           register_instance_option :delete_method do
-            "remove_#{name}"
+            "remove_#{name}" if bindings[:object].respond_to?("remove_#{name}")
           end
 
           register_instance_option :cache_method do

--- a/lib/rails_admin_shrine.rb
+++ b/lib/rails_admin_shrine.rb
@@ -1,11 +1,7 @@
 require "rails_admin_shrine/engine"
-
-module RailsAdminShrine
-end
-
-require 'rails_admin/config/fields'
-require 'rails_admin/config/fields/base'
-require 'rails_admin/config/fields/types/file_upload'
+require "rails_admin/config/fields"
+require "rails_admin/config/fields/base"
+require "rails_admin/config/fields/types/file_upload"
 
 module RailsAdmin
   module Config
@@ -16,15 +12,13 @@ module RailsAdmin
 
           register_instance_option :thumb_method do
             unless defined? @thumb_method
-              @thumb_method ||= begin              
-                attacher = bindings[:object].try("#{name}_attacher".to_sym)              
-                if attacher
-                  versions = attacher.shrine_class.version_names 
-                  versions.detect{|v| v.in?([:thumb, :thumbnail, 'thumb', 'thumbnail']) } || versions.first.to_s
-                end  
+              @thumb_method = begin
+                attacher = bindings[:object].public_send("#{name}_attacher".to_sym)
+                versions = attacher.shrine_class.version_names.map { |v| v.to_sym }
+                versions.detect { |v| v.in?(%i[thumb thumbnail]) } || versions.first
               end
             end
-            @thumb_method  
+            @thumb_method
           end
 
           register_instance_option :delete_method do
@@ -36,12 +30,13 @@ module RailsAdmin
           end
 
           def resource_url(thumb = false)
-            return nil unless (uploader = bindings[:object].send(name)).present?                        
-            if uploader.is_a? Hash # has versions
-              thumb.present? ? uploader[thumb].url : uploader[uploader.keys.first].url
+            return nil unless value
+
+            if value.is_a?(Hash)
+              value[thumb || value.keys.first].url
             else
-              uploader.url  
-            end  
+              value.url
+            end
           end
         end
       end
@@ -50,24 +45,25 @@ module RailsAdmin
 end
 
 RailsAdmin::Config::Fields.register_factory do |parent, properties, fields|
-  model = parent.abstract_model.model  
-  if defined?(::Shrine) && (attachment_names = (model).ancestors.select{|m| m.is_a? Shrine::Attachment}.map{|a| a.instance_variable_get("@name")}).any? && (attachment_name = attachment_names.detect{|a| a == properties.name.to_s.chomp('_data').to_sym})
-    columns = [attachment_name, "#{attachment_name}_data".to_sym]
-    field = RailsAdmin::Config::Fields::Types.load(:shrine).new(parent, attachment_name, properties)
-    fields << field
-    children_fields = []
-    columns.each do |children_column_name|
-      next unless child_properties = parent.abstract_model.properties.detect { |p| p.name.to_s == children_column_name.to_s }
-      children_field = fields.detect { |f| f.name == children_column_name } || RailsAdmin::Config::Fields.default_factory.call(parent, child_properties, fields)
-      children_field.hide unless field == children_field
-      children_field.filterable(false) unless field == children_field
-      children_fields << children_field.name
-    end
-    field.children_fields(children_fields)
-    true
-  else
-    false
-  end
+  next false unless defined?(::Shrine)
+
+  attachment_names = (parent.abstract_model.model).ancestors.select { |m| m.is_a?(Shrine::Attachment) }.map{ |a| a.instance_variable_get("@name") }
+  next false if attachment_names.blank?
+
+  attachment_name = attachment_names.detect { |a| a == properties.name.to_s.chomp('_data').to_sym }
+  next false unless attachment_name
+
+  field = RailsAdmin::Config::Fields::Types.load(:shrine).new(parent, attachment_name, properties)
+  fields << field
+
+  data_field_name = "#{attachment_name}_data".to_sym
+  child_properties = parent.abstract_model.properties.detect { |p| p.name == data_field_name }
+  next true unless child_properties
+
+  children_field = fields.detect { |f| f.name == data_field_name } || RailsAdmin::Config::Fields.default_factory.call(parent, child_properties, fields)
+  children_field.hide unless field == children_field
+  children_field.filterable(false) unless field == children_field
+
+  field.children_fields([data_field_name])
+  true
 end
-
-

--- a/lib/rails_admin_shrine.rb
+++ b/lib/rails_admin_shrine.rb
@@ -35,11 +35,12 @@ module RailsAdmin
             "cached_#{name}_data"
           end
 
-          def resource_url(thumb = false)
+          def resource_url(thumb = nil)
             return nil unless value
 
             if value.is_a?(Hash)
-              value[thumb || value.keys.first].url
+              key = thumb || (value.key?(:original) ? :original : value.keys.first)
+              value[key].url
             else
               value.url
             end

--- a/lib/rails_admin_shrine/version.rb
+++ b/lib/rails_admin_shrine/version.rb
@@ -1,3 +1,3 @@
 module RailsAdminShrine
-  VERSION = "0.0.2"
+  VERSION = '0.0.3'
 end


### PR DESCRIPTION
- Improved README
- Now delete method may be undefined
- No using of version_names method (as it is deprecated)
- Made small refactoring

I'm not sure about versions.
With `rails_admin (1.4.2)` and `shrine (2.12.0)` it works perfectly